### PR TITLE
fix: validate duplicate issue with project id

### DIFF
--- a/apps/api/src/domains/project/issue/issue.service.spec.ts
+++ b/apps/api/src/domains/project/issue/issue.service.spec.ts
@@ -21,7 +21,6 @@ import { Like, Repository } from 'typeorm';
 import { TimeRange } from '@/common/dtos';
 import { createQueryBuilder, mockRepository } from '@/utils/test-utils';
 
-// import { ProjectEntity } from '../project/project.entity';
 import {
   CreateIssueDto,
   FindIssuesByProjectIdDto,

--- a/apps/api/src/domains/project/issue/issue.service.ts
+++ b/apps/api/src/domains/project/issue/issue.service.ts
@@ -56,6 +56,7 @@ export class IssueService {
 
     const duplicateIssue = await this.repository.findOneBy({
       name: issue.name,
+      project: { id: issue.project.id },
     });
 
     if (duplicateIssue) throw new IssueNameDuplicatedException();


### PR DESCRIPTION
Validating an issue before creating should be done with the project id, not only its name.