### PR TITLE
added a reference to the swagger endpoint in the backend readme

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -92,6 +92,10 @@ npm run migration:run
 | MASTER_API_KEY       | set a key if you want to make a master key for creating feedback                 |                                                                    |
 | NODE_OPTIONS         | set some options if you want to add for node execution (e.g. max_old_space_size) |                                                                    |
 
+## Swagger
+
+The swagger documentation can be found on the `/docs` endpoint.
+
 ## Learn More
 
 To learn NestJS, check out the [NestJS documentation](https://nestjs.com/).


### PR DESCRIPTION
Hi!

Since the frontend does not seem to implement all needed functions yet (e.g. creating projects), I ended up using the API to help me get started.

Therefore I felt like it would be a good idea to mention the swagger documentation in the readme.