### PR TITLE
Revert "chore(deps): bump prettier from 3.0.3 to 3.2.4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@manypkg/cli": "^0.21.0",
     "@ufb/prettier-config": "^0.1.0",
     "husky": "^8.0.3",
-    "prettier": "^3.2.4",
+    "prettier": "^3.0.3",
     "turbo": "^1.10.16",
     "typescript": "^5.2.2"
   },

--- a/packages/ufb-tailwind/package.json
+++ b/packages/ufb-tailwind/package.json
@@ -25,7 +25,7 @@
     "postcss-import": "^15.1.0",
     "postcss-nesting": "^12.0.1",
     "prejss-cli": "^0.3.3",
-    "prettier": "^3.2.4",
+    "prettier": "^3.0.3",
     "tailwindcss": "^3.3.3"
   }
 }

--- a/tooling/prettier/package.json
+++ b/tooling/prettier/package.json
@@ -11,7 +11,7 @@
   "prettier": "@ufb/prettier-config",
   "dependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
-    "prettier": "^3.2.4",
+    "prettier": "^3.0.3",
     "prettier-plugin-tailwindcss": "^0.5.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12252,10 +12252,10 @@ prettier-plugin-tailwindcss@^0.5.6:
   resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.6.tgz#8e511857a49bf127f078985f52b04a70e8e92285"
   integrity sha512-2Xgb+GQlkPAUCFi3sV+NOYcSI5XgduvDBL2Zt/hwJudeKXkyvRS65c38SB0yb9UB40+1rL83I6m0RtlOQ8eHdg==
 
-prettier@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.4.tgz#4723cadeac2ce7c9227de758e5ff9b14e075f283"
-  integrity sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==
+prettier@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 pretty-format@^27.0.2:
   version "27.5.1"


### PR DESCRIPTION
Latest prettier (3.2.4) has some issues of parsing JSON type files (e.g. tsconfig.json) with trailing comma.