### PR TITLE
fix: more button in feedback detail

### DIFF
--- a/apps/web/src/hooks/useTruncatedElement.tsx
+++ b/apps/web/src/hooks/useTruncatedElement.tsx
@@ -14,19 +14,29 @@
  * under the License.
  */
 import type { RefObject } from 'react';
-import { useLayoutEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const useTruncatedElement = ({ ref }: { ref: RefObject<HTMLElement> }) => {
   const [isTruncated, setIsTruncated] = useState(false);
   const [isShowingMore, setIsShowingMore] = useState(false);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!ref.current) return;
-    const { offsetHeight, scrollHeight } = ref.current;
 
-    if (offsetHeight + 1 < scrollHeight) setIsTruncated(true);
-    else setIsTruncated(false);
-  }, [ref.current?.innerHTML]);
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { offsetHeight, scrollHeight } = entry.target as HTMLDivElement;
+        if (offsetHeight + 1 < scrollHeight) {
+          setIsTruncated(true);
+          observer.disconnect();
+        } else setIsTruncated(false);
+      }
+    });
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref.current]);
 
   const toggleIsShowingMore = () => setIsShowingMore((prev) => !prev);
 


### PR DESCRIPTION
The issue is that a more button does not appear in feedback detail component.
![image](https://github.com/line/abc-user-feedback/assets/21219546/cd888b12-a449-40e4-b2c5-748a23a6dc65)

This issue is fixed through ResizeObserver