### PR TITLE
chore: fix setup docker infra file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ pnpm install
 2. Spin up all required infrastructure (Mysql, OpenSearch, etc.) using Docker Compose:
 
 ```bash
-docker-compose -f docker-compose.infra.yml up -d
+docker-compose -f docker/docker-compose.infra.yml up -d
 ```
 
 3. Make an `.env` file in `apps/api` and `apps/web` by referring to `.env.example` ([web environment variables](./apps/web/README.md), [api environment variables](./apps/api/README.md))


### PR DESCRIPTION
Following the Docker setup instructions does not work due to the incorrect path for the Docker Compose file specified in the README.

```
❯ docker-compose -f docker-compose.infra.yml up -d
stat /Users/bh/workspaces/chore/abc-user-feedback/docker-compose.infra.yml: no such file or directory
```

The docker-compose.infra.yml file is actually located at `docker/docker-compose.infra.yml`.

The README should be updated to reflect the correct path.

---

The path `docker/docker-compose.infra.yml` works successfully.

![스크린샷 2024-06-04 오전 6 21 16](https://github.com/line/abc-user-feedback/assets/50096419/ed74dda1-ca0a-4747-a764-adf7bbfb6fd6)

