### PR TITLE
fix: refactor docker mysql

### DIFF
--- a/docker/docker-compose.infra-amd64.yml
+++ b/docker/docker-compose.infra-amd64.yml
@@ -2,7 +2,7 @@ services:
   mysql:
     hostname: mysql
     image: mysql:8.4.0
-    platform: linux/arm64/v8
+    platform: linux/amd64
     restart: always
     command: [--mysql-native-password=ON]
     environment:
@@ -22,7 +22,7 @@ services:
   mysql-for-e2e:
     hostname: mysql
     image: mysql:8.4.0
-    platform: linux/arm64/v8
+    platform: linux/amd64
     restart: always
     command: [--mysql-native-password=ON]
     environment:
@@ -63,7 +63,7 @@ services:
       - bootstrap.memory_lock=true
       - 'OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m'
       - plugins.security.disabled=true
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=AIotplatform9((
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=userfeedback
     ulimits:
       memlock:
         soft: -1

--- a/docker/docker-compose.infra-armd64.yml
+++ b/docker/docker-compose.infra-armd64.yml
@@ -1,0 +1,98 @@
+services:
+  mysql:
+    hostname: mysql
+    image: mysql:8.4.0
+    platform: linux/arm64/v8
+    restart: always
+    command: [--mysql-native-password=ON]
+    environment:
+      MYSQL_ROOT_PASSWORD: userfeedback
+      MYSQL_DATABASE: userfeedback
+      MYSQL_USER: userfeedback
+      MYSQL_PASSWORD: userfeedback
+      TZ: UTC
+    ports:
+      - 13306:3306
+    volumes:
+      - ./volumes/mysql:/var/lib/mysql
+    networks:
+      - app_network
+
+  # optional for e2e test
+  mysql-for-e2e:
+    hostname: mysql
+    image: mysql:8.4.0
+    platform: linux/arm64/v8
+    restart: always
+    command: [--mysql-native-password=ON]
+    environment:
+      MYSQL_ROOT_PASSWORD: userfeedback
+      MYSQL_DATABASE: e2e
+      MYSQL_USER: userfeedback
+      MYSQL_PASSWORD: userfeedback
+      TZ: UTC
+    ports:
+      - 13307:3306
+    volumes:
+      - ./volumes/mysql-for-e2e:/var/lib/mysql-for-e2e
+    networks:
+      - app_network
+
+  # optional for email verification on creating user
+  smtp4dev:
+    image: rnwood/smtp4dev:v3
+    restart: always
+    ports:
+      - 5080:80
+      - 25:25
+      - 143:143
+    volumes:
+      - ./volumes/smtp4dev:/smtp4dev
+    networks:
+      - app_network
+
+  # optional for better performance on searching feedbacks
+  opensearch-node:
+    image: opensearchproject/opensearch:2.14.0
+    restart: always
+    container_name: opensearch-node
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - 'OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m'
+      - plugins.security.disabled=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=userfeedback
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - ./volumes/opensearch:/usr/share/opensearch/data
+    ports:
+      - 9200:9200
+      - 9600:9600
+    networks:
+      - app_network
+
+  # optional for opensearch
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:2.14.0
+    restart: always
+    container_name: opensearch-dashboards
+    ports:
+      - 5601:5601
+    environment:
+      - 'OPENSEARCH_HOSTS=["http://opensearch-node:9200"]'
+      - 'DISABLE_SECURITY_DASHBOARDS_PLUGIN=true'
+    depends_on:
+      - opensearch-node
+    networks:
+      - app_network
+
+networks:
+  app_network:

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -1,12 +1,10 @@
-version: '3'
-
 services:
   mysql:
     hostname: mysql
     image: mysql:8.4.0
-    platform: linux/amd64
+    platform: linux/arm64/v8
     restart: always
-    command: --default-authentication-plugin=mysql_native_password
+    command: [--mysql-native-password=ON]
     environment:
       MYSQL_ROOT_PASSWORD: userfeedback
       MYSQL_DATABASE: userfeedback
@@ -24,9 +22,9 @@ services:
   mysql-for-e2e:
     hostname: mysql
     image: mysql:8.4.0
-    platform: linux/amd64
+    platform: linux/arm64/v8
     restart: always
-    command: --default-authentication-plugin=mysql_native_password
+    command: [--mysql-native-password=ON]
     environment:
       MYSQL_ROOT_PASSWORD: userfeedback
       MYSQL_DATABASE: e2e
@@ -65,6 +63,7 @@ services:
       - bootstrap.memory_lock=true
       - 'OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m'
       - plugins.security.disabled=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=AIotplatform9((
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
Hello, thank you for creating a great project. 

Command differences and opensearch password settings have been added depending on the mysql service version. 

I changed the platform settings based on my operating system.

My operating system environment is as follows.

OS : Apple M1 Pro, Ventura 13.4 
Docker Version: Docker Desktop v26.1.4
Editor: Visual Studio Code

PS. When executing the command below, I wish there was a message telling you to delete the docker/volume folder and then run it.

> 2. Spin up all required infrastructure (Mysql, OpenSearch, etc.) using Docker Compose:
> docker-compose -f docker/docker-compose.infra.yml up -d

https://dev.mysql.com/doc/refman/8.4/en/data-directory-initialization.html#data-directory-initialization-overview

> If the data directory exists but is not empty (that is, it contains files or subdirectories), the server exits after producing an error message:

> [ERROR] --initialize specified but the data directory exists. Aborting.

The reason is that because it checks whether the data directory exists as above, an error such as a link occurs. 

thank you
