### PR TITLE
fix redoc error

### DIFF
--- a/apps/api/src/domains/api/api.controller.ts
+++ b/apps/api/src/domains/api/api.controller.ts
@@ -13,26 +13,19 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { HttpService } from '@nestjs/axios';
 import { Controller, Get, Req, Res } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
-import { AxiosError, AxiosResponse } from 'axios';
 import { FastifyReply, FastifyRequest } from 'fastify';
-import { lastValueFrom } from 'rxjs';
 
 @Controller()
 @ApiExcludeController()
 export class APIController {
-  constructor(private readonly httpService: HttpService) {}
-
   @Get('docs/redoc')
   async getAPIDocs(
     @Req() request: FastifyRequest,
     @Res() reply: FastifyReply,
   ): Promise<void> {
     const { hostname } = request;
-    let specUrl = `https://${hostname}/docs-json`;
-    }
 
     const html = `<!DOCTYPE html>
     <html>
@@ -54,7 +47,7 @@ export class APIController {
         </style>
       </head>
       <body>
-        <redoc spec-url='${specUrl}'></redoc>
+        <redoc spec-url='//${hostname}/docs-json'></redoc>
         <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
       </body>
     </html>`;

--- a/apps/api/src/domains/api/api.controller.ts
+++ b/apps/api/src/domains/api/api.controller.ts
@@ -30,12 +30,8 @@ export class APIController {
     @Res() reply: FastifyReply,
   ): Promise<void> {
     const { hostname } = request;
-    let specUrl = `https://${hostname}/docs-json`;
-    try {
-      await lastValueFrom(this.httpService.head(specUrl));
-    } catch (e) {
-      specUrl = `http://${hostname}/docs-json`;
-    }
+    const specUrl = `https://${hostname}/docs-json`;
+    await lastValueFrom(this.httpService.head(specUrl));
 
     const html = `<!DOCTYPE html>
     <html>

--- a/apps/api/src/domains/api/api.controller.ts
+++ b/apps/api/src/domains/api/api.controller.ts
@@ -31,6 +31,15 @@ export class APIController {
     @Res() reply: FastifyReply,
   ): Promise<void> {
     const { hostname } = request;
+    const swaggerUrl =
+      'https://abc-userfeedback-api-alpha-abc-ufb.app.linecorp-dev.com/docs';
+    try {
+      await lastValueFrom(this.httpService.head(swaggerUrl));
+      console.log(`Swagger URL ${swaggerUrl} is accessible`);
+    } catch (e: any) {
+      console.error(`HTTPS check failed for ${swaggerUrl}:`, e.message);
+    }
+
     let specUrl = `https://${hostname}/docs-json`;
     try {
       await lastValueFrom(this.httpService.head(specUrl));

--- a/apps/api/src/domains/api/api.controller.ts
+++ b/apps/api/src/domains/api/api.controller.ts
@@ -31,40 +31,7 @@ export class APIController {
     @Res() reply: FastifyReply,
   ): Promise<void> {
     const { hostname } = request;
-    const swaggerUrl =
-      'https://abc-userfeedback-api-alpha-abc-ufb.app.linecorp-dev.com/docs';
-    try {
-      await lastValueFrom(this.httpService.head(swaggerUrl));
-      console.log(`Swagger URL ${swaggerUrl} is accessible`);
-    } catch (e: any) {
-      console.error(`HTTPS check failed for ${swaggerUrl}:`, e.message);
-    }
-
     let specUrl = `https://${hostname}/docs-json`;
-    try {
-      await lastValueFrom(this.httpService.head(specUrl));
-    } catch (e: any) {
-      // Log the error for debugging purposes
-      console.error(`HTTPS check failed for ${specUrl}:`, e.message);
-
-      // Check if the error is due to network issues or 404 status
-      if (
-        e.response &&
-        (e.response.status === 404 || e.response.status === 500)
-      ) {
-        specUrl = `http://${hostname}/docs-json`;
-        try {
-          await lastValueFrom(this.httpService.head(specUrl));
-        } catch (httpError) {
-          console.error(`HTTP check failed for ${specUrl}:`, httpError.message);
-          // Handle the case where both HTTPS and HTTP fail
-          throw new Error(`Both HTTPS and HTTP checks failed for ${hostname}`);
-        }
-      } else {
-        // Re-throw other types of errors
-        console.error('Unknown error!');
-        throw e;
-      }
     }
 
     const html = `<!DOCTYPE html>


### PR DESCRIPTION
- Fixes the error that the `docs/redoc` page is not rendered properly in deployed environment.
  - It seems eslint major version upgrade in [this pull request](https://github.com/line/abc-user-feedback/pull/367) affected to Nest.js behaviour, so `HTTP HEAD Request` to `https://${hostname}/docs-json` would not work anymore.