### PR TITLE
fix feedback update bug

### DIFF
--- a/apps/api/integration-test/test-specs/channel.integration-spec.ts
+++ b/apps/api/integration-test/test-specs/channel.integration-spec.ts
@@ -205,6 +205,22 @@ describe('ChannelController (integration)', () => {
           expect(body.fields[4].name).toBe('TestFieldUpdated');
         });
     });
+
+    it('should return 400 error when update channel fields with special character', async () => {
+      const dto = new UpdateChannelFieldsRequestDto();
+      const fieldDto = new UpdateChannelRequestFieldDto();
+      fieldDto.id = 5;
+      fieldDto.format = FieldFormatEnum.text;
+      fieldDto.key = 'testField';
+      fieldDto.name = '!';
+      dto.fields = [fieldDto];
+
+      await request(app.getHttpServer() as Server)
+        .put(`/admin/projects/${project.id}/channels/1/fields`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send(dto)
+        .expect(400);
+    });
   });
 
   describe('/admin/projects/:projectId/channels/:channelId (DELETE)', () => {

--- a/apps/api/src/domains/admin/channel/field/field.mysql.service.ts
+++ b/apps/api/src/domains/admin/channel/field/field.mysql.service.ts
@@ -50,6 +50,11 @@ export class FieldMySQLService {
     if (!validateUnique(fields, 'key')) {
       throw new FieldKeyDuplicatedException();
     }
+    fields.forEach(({ name }) => {
+      if (/^[a-z0-9_-]+$/i.test(name) === false) {
+        throw new BadRequestException('field name should be alphanumeric');
+      }
+    });
     fields.forEach(({ format, options }) => {
       if (!this.isValidField(format, options ?? [])) {
         throw new BadRequestException('only select format field has options');

--- a/apps/api/src/domains/admin/feedback/feedback.mysql.service.ts
+++ b/apps/api/src/domains/admin/feedback/feedback.mysql.service.ts
@@ -292,12 +292,13 @@ export class FeedbackMySQLService {
           }
           let query = `JSON_SET(IFNULL(feedbacks.data,'{}'), `;
           for (const [index, fieldKey] of Object.entries(Object.keys(data))) {
-            query += `'$."${fieldKey}"', ${
+            query += `'$.${fieldKey}',
+            ${
               Array.isArray(data[fieldKey]) ?
                 data[fieldKey].length === 0 ?
                   'JSON_ARRAY()'
                 : 'JSON_ARRAY("' + data[fieldKey].join('","') + '")'
-              : '"' + data[fieldKey] + '"'
+              : `:${fieldKey}`
             }`;
 
             if (parseInt(index) + 1 !== Object.entries(data).length) {
@@ -311,6 +312,7 @@ export class FeedbackMySQLService {
         updatedAt: () => `'${DateTime.utc().toFormat('yyyy-MM-dd HH:mm:ss')}'`,
       })
       .where('id = :feedbackId', { feedbackId })
+      .setParameters(data)
       .execute();
   }
 

--- a/apps/api/src/test-utils/fixtures.ts
+++ b/apps/api/src/test-utils/fixtures.ts
@@ -78,8 +78,8 @@ export const createFieldDto = (input: Partial<CreateFieldDto> = {}) => {
   const property = input.property ?? getRandomEnumValue(FieldPropertyEnum);
   const status = input.status ?? getRandomEnumValue(FieldStatusEnum);
   return {
-    name: faker.string.alphanumeric(20),
-    key: faker.string.alphanumeric(20),
+    name: `_${faker.string.alphanumeric(20)}`,
+    key: `_${faker.string.alphanumeric(20)}`,
     description: faker.lorem.lines(2),
     format,
     property,


### PR DESCRIPTION
- Fix feedback update bug that the field which contains a question mark causes server error
- The following example is a JSON request that causes an issue.

```json
{
    "createdAt": "2024-09-29T09:50:00",
    "message": "?"
}
```

- Allow only alphanumeric character for field name
  - A special character causes server error 