### PR TITLE
block sign in with not allowed domain

### DIFF
--- a/apps/api/src/domains/admin/auth/auth.service.ts
+++ b/apps/api/src/domains/admin/auth/auth.service.ts
@@ -181,6 +181,15 @@ export class AuthService {
   async signIn(user: UserDto): Promise<JwtDto> {
     const { email, id, department, name, type } = user;
 
+    const { allowDomains } = await this.tenantService.findOne();
+
+    if (email && allowDomains) {
+      const domain = email.substring(email.lastIndexOf('@') + 1);
+      if (!allowDomains.includes(domain)) {
+        throw new BadRequestException('Signed in with invalid domain.');
+      }
+    }
+
     const { state } = await this.userService.findById(id);
 
     if (state === UserStateEnum.Blocked) throw new UserBlockedException();

--- a/apps/api/src/domains/admin/auth/auth.service.ts
+++ b/apps/api/src/domains/admin/auth/auth.service.ts
@@ -183,7 +183,7 @@ export class AuthService {
 
     const { allowDomains } = await this.tenantService.findOne();
 
-    if (email && allowDomains) {
+    if (email && allowDomains && allowDomains.length > 0) {
       const domain = email.substring(email.lastIndexOf('@') + 1);
       if (!allowDomains.includes(domain)) {
         throw new BadRequestException('Signed in with invalid domain.');


### PR DESCRIPTION
- Block any sign-in request with not allowed domain
  - Allowed domains are registered with whitelist in the admin setting page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced sign-in security by validating email domains against allowed lists, ensuring only authorized domains can sign in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->