### PR TITLE
feat: improve external search api

### DIFF
--- a/apps/api/src/domains/admin/channel/field/dtos/responses/find-fields-response.dto.ts
+++ b/apps/api/src/domains/admin/channel/field/dtos/responses/find-fields-response.dto.ts
@@ -103,5 +103,5 @@ export class GetFieldsResponseDto {
   format: FieldFormatEnum;
 
   @ApiProperty({ enum: FieldStatusEnum })
-  status: FieldFormatEnum;
+  status: FieldStatusEnum;
 }

--- a/apps/api/src/domains/admin/channel/field/dtos/responses/find-fields-response.dto.ts
+++ b/apps/api/src/domains/admin/channel/field/dtos/responses/find-fields-response.dto.ts
@@ -88,3 +88,20 @@ export class FindFieldsResponseDto {
     });
   }
 }
+
+export class GetFieldsResponseDto {
+  @ApiProperty({ example: 1 })
+  id: number;
+
+  @ApiProperty({ example: 'fieldName' })
+  name: string;
+
+  @ApiProperty({ example: 'fieldKey' })
+  key: string;
+
+  @ApiProperty({ enum: FieldFormatEnum })
+  format: FieldFormatEnum;
+
+  @ApiProperty({ enum: FieldStatusEnum })
+  status: FieldFormatEnum;
+}

--- a/apps/api/src/domains/admin/feedback/dtos/requests/find-feedbacks-by-channel-id-request-v2.dto.ts
+++ b/apps/api/src/domains/admin/feedback/dtos/requests/find-feedbacks-by-channel-id-request-v2.dto.ts
@@ -21,22 +21,34 @@ import { QueryV2ConditionsEnum, SortMethodEnum } from '@/common/enums';
 import { IsNullable } from '@/domains/admin/user/decorators';
 
 class QueryV2 {
-  @ApiProperty({ required: false })
+  @ApiProperty({
+    description: 'Feedback IDs that are being requested.',
+    required: false,
+  })
   @IsOptional()
   @IsArray()
   ids?: number[];
 
-  @ApiProperty({ required: true })
+  @ApiProperty({
+    description:
+      'Indicates the key string of field that are being requested as a condition. For example: "createdAt", "message", "issueIds".',
+    required: true,
+  })
   @IsString()
   key: string;
 
-  @ApiProperty({ required: true })
+  @ApiProperty({
+    description:
+      'Indicates the value of field that are being requested as a condition. This can be a type of string, number, TimeRange, or array of string and number.',
+    required: true,
+  })
   @IsNullable()
   value: string | string[] | TimeRange | number | number[] | undefined;
 
   @ApiProperty({
     enum: QueryV2ConditionsEnum,
     enumName: 'QueryV2ConditionsEnum',
+    description: 'Condition of the query.',
   })
   @IsEnum(QueryV2ConditionsEnum)
   condition: QueryV2ConditionsEnum;
@@ -45,7 +57,8 @@ class QueryV2 {
 export class FindFeedbacksByChannelIdRequestDtoV2 extends PaginationRequestDto {
   @ApiProperty({
     required: false,
-    description: 'You can query by key-value with this object.',
+    description:
+      "You can query by key-value with this object. Queries are concatenated with 'AND' or 'OR' operator.",
     type: [QueryV2],
   })
   @IsOptional()
@@ -54,7 +67,7 @@ export class FindFeedbacksByChannelIdRequestDtoV2 extends PaginationRequestDto {
   @ApiProperty({
     required: false,
     description:
-      'You can query by key-value with this object by default (like createdAt).',
+      'You can query by key-value with this object by default (like createdAt). This condition always applies regardless of the conditions of the queries.',
     type: [QueryV2],
   })
   @IsOptional()

--- a/apps/api/src/domains/admin/feedback/dtos/requests/get-feedbacks-by-channel-id-request.dto.ts
+++ b/apps/api/src/domains/admin/feedback/dtos/requests/get-feedbacks-by-channel-id-request.dto.ts
@@ -21,12 +21,15 @@ import { toNumber } from '@/common/helper/cast.helper';
 
 export class GetFeedbacksByChannelIdRequestDto {
   @ApiProperty({ required: true, description: 'Keyword to search feedbacks' })
-  @IsOptional()
   @IsString()
   searchText: string;
 
+  @ApiProperty({ required: true, description: 'Field key to search feedbacks' })
+  @IsString()
+  fieldKey: string;
+
   @ApiProperty({
-    required: true,
+    required: false,
     description: 'Issue name to search related feedbacks within channel',
   })
   @IsOptional()

--- a/apps/api/src/domains/admin/feedback/dtos/requests/get-feedbacks-by-channel-id-request.dto.ts
+++ b/apps/api/src/domains/admin/feedback/dtos/requests/get-feedbacks-by-channel-id-request.dto.ts
@@ -40,7 +40,7 @@ export class GetFeedbacksByChannelIdRequestDto {
   @IsOptional()
   @IsNumber()
   @Min(1)
-  limit: number;
+  limit = 10;
 
   @Transform(({ value }: { value: string }) =>
     toNumber(value, { default: 1, min: 1 }),
@@ -49,5 +49,5 @@ export class GetFeedbacksByChannelIdRequestDto {
   @IsOptional()
   @IsNumber()
   @Min(1)
-  page: number;
+  page = 1;
 }

--- a/apps/api/src/domains/admin/feedback/dtos/requests/get-feedbacks-by-channel-id-request.dto.ts
+++ b/apps/api/src/domains/admin/feedback/dtos/requests/get-feedbacks-by-channel-id-request.dto.ts
@@ -20,11 +20,16 @@ import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
 import { toNumber } from '@/common/helper/cast.helper';
 
 export class GetFeedbacksByChannelIdRequestDto {
-  @ApiProperty({ required: true, description: 'Keyword to search feedbacks' })
+  @ApiProperty({ required: false, description: 'Keyword to search feedbacks' })
+  @IsOptional()
   @IsString()
   searchText: string;
 
-  @ApiProperty({ required: true, description: 'Field key to search feedbacks' })
+  @ApiProperty({
+    required: false,
+    description: 'Field key to search feedbacks',
+  })
+  @IsOptional()
   @IsString()
   fieldKey: string;
 

--- a/apps/api/src/domains/admin/feedback/dtos/requests/get-feedbacks-by-channel-id-request.dto.ts
+++ b/apps/api/src/domains/admin/feedback/dtos/requests/get-feedbacks-by-channel-id-request.dto.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
+
+import { toNumber } from '@/common/helper/cast.helper';
+
+export class GetFeedbacksByChannelIdRequestDto {
+  @ApiProperty({ required: true, description: 'Keyword to search feedbacks' })
+  @IsOptional()
+  @IsString()
+  searchText: string;
+
+  @ApiProperty({
+    required: true,
+    description: 'Issue name to search related feedbacks within channel',
+  })
+  @IsOptional()
+  @IsString()
+  issueName: string;
+
+  @Transform(({ value }: { value: string }) =>
+    toNumber(value, { default: 10, min: 1 }),
+  )
+  @ApiProperty({ required: false, minimum: 1, default: 10, example: 10 })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  limit: number;
+
+  @Transform(({ value }: { value: string }) =>
+    toNumber(value, { default: 1, min: 1 }),
+  )
+  @ApiProperty({ required: false, minimum: 1, default: 1, example: 1 })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  page: number;
+}

--- a/apps/api/src/domains/admin/feedback/feedback.service.ts
+++ b/apps/api/src/domains/admin/feedback/feedback.service.ts
@@ -624,6 +624,7 @@ export class FeedbackService {
       }
     }
     delete dto.query?.issueName;
+    if (!dto.query?.searchText) delete dto.query?.searchText;
 
     this.validateQuery(dto.query ?? {}, fields);
 

--- a/apps/api/src/domains/admin/feedback/feedback.service.ts
+++ b/apps/api/src/domains/admin/feedback/feedback.service.ts
@@ -117,6 +117,9 @@ export class FeedbackService {
       if ('searchText' === fieldKey) {
         continue;
       }
+      if ('issueName' === fieldKey) {
+        continue;
+      }
       if ('condition' === fieldKey) {
         continue;
       }
@@ -595,6 +598,18 @@ export class FeedbackService {
       throw new BadRequestException('invalid channel');
     }
     dto.fields = fields;
+
+    if (dto.query?.issueName) {
+      const issue = await this.issueService.findByName({
+        name: dto.query.issueName as string,
+      });
+      if (issue) {
+        dto.query.issueIds = [issue.id];
+      } else {
+        dto.query.issueIds = [];
+      }
+    }
+    delete dto.query?.issueName;
 
     this.validateQuery(dto.query ?? {}, fields);
 

--- a/apps/api/src/domains/admin/feedback/feedback.service.ts
+++ b/apps/api/src/domains/admin/feedback/feedback.service.ts
@@ -117,6 +117,9 @@ export class FeedbackService {
       if ('searchText' === fieldKey) {
         continue;
       }
+      if ('fieldKey' === fieldKey) {
+        continue;
+      }
       if ('issueName' === fieldKey) {
         continue;
       }
@@ -597,7 +600,18 @@ export class FeedbackService {
     if (fields.length === 0) {
       throw new BadRequestException('invalid channel');
     }
-    dto.fields = fields;
+    if (dto.query?.fieldKey) {
+      const field = fields.find((v) => v.key === dto.query?.fieldKey);
+      if (!field) {
+        throw new BadRequestException(
+          'invalid field key: ' + dto.query.fieldKey.toString(),
+        );
+      }
+      dto.fields = [field];
+    } else {
+      dto.fields = fields;
+    }
+    delete dto.query?.fieldKey;
 
     if (dto.query?.issueName) {
       const issue = await this.issueService.findByName({

--- a/apps/api/src/domains/api/api.module.ts
+++ b/apps/api/src/domains/api/api.module.ts
@@ -40,6 +40,7 @@ import { ChannelController } from './channel.controller';
 import { FeedbackController } from './feedback.controller';
 import { IssueController } from './issue.controller';
 import { ProjectController } from './project.controller';
+import { FeedbackV2Controller } from './v2/feedback.controller';
 
 @Module({
   imports: [
@@ -67,6 +68,7 @@ import { ProjectController } from './project.controller';
   ],
   controllers: [
     FeedbackController,
+    FeedbackV2Controller,
     IssueController,
     APIController,
     ChannelController,

--- a/apps/api/src/domains/api/feedback.controller.ts
+++ b/apps/api/src/domains/api/feedback.controller.ts
@@ -267,7 +267,7 @@ export class FeedbackController {
 
   @ApiOperation({
     summary: 'Get Feedbacks by Channel',
-    description: `Searches for feedback entries by channel ID with keyword.`,
+    description: `Searches for feedback entries by channel ID with keyword. You can search by specifying both fieldKey and searchText, or by specifying issueName.`,
   })
   @ApiParam({
     name: 'projectId',
@@ -287,18 +287,26 @@ export class FeedbackController {
     @Param('channelId', ParseIntPipe) channelId: number,
     @Query() body: GetFeedbacksByChannelIdRequestDto,
   ) {
-    return FindFeedbacksByChannelIdResponseDto.transform(
-      await this.feedbackService.findByChannelId({
-        page: body.page,
-        limit: body.limit,
-        query: {
-          searchText: body.searchText,
-          fieldKey: body.fieldKey,
-          issueName: body.issueName,
-        },
-        channelId,
-      }),
-    );
+    const { page, limit, searchText, fieldKey, issueName } = body;
+
+    if (issueName || (fieldKey && searchText)) {
+      return FindFeedbacksByChannelIdResponseDto.transform(
+        await this.feedbackService.findByChannelId({
+          page,
+          limit,
+          query: {
+            searchText,
+            fieldKey,
+            issueName,
+          },
+          channelId,
+        }),
+      );
+    } else {
+      throw new BadRequestException(
+        'Please provide either issueName or both fieldKey and searchText.',
+      );
+    }
   }
 
   @ApiOperation({

--- a/apps/api/src/domains/api/feedback.controller.ts
+++ b/apps/api/src/domains/api/feedback.controller.ts
@@ -293,6 +293,7 @@ export class FeedbackController {
         limit: body.limit,
         query: {
           searchText: body.searchText,
+          fieldKey: body.fieldKey,
           issueName: body.issueName,
         },
         channelId,

--- a/apps/api/src/domains/api/feedback.controller.ts
+++ b/apps/api/src/domains/api/feedback.controller.ts
@@ -24,6 +24,7 @@ import {
   ParseIntPipe,
   Post,
   Put,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -44,6 +45,7 @@ import {
   DeleteFeedbacksRequestDto,
   FindFeedbacksByChannelIdRequestDto,
 } from '../admin/feedback/dtos/requests';
+import { GetFeedbacksByChannelIdRequestDto } from '../admin/feedback/dtos/requests/get-feedbacks-by-channel-id-request.dto';
 import {
   AddIssueResponseDto,
   FindFeedbacksByChannelIdResponseDto,
@@ -251,7 +253,7 @@ export class FeedbackController {
     description: 'Channel id',
     example: 1,
   })
-  @ApiBody({ type: FindFeedbacksByChannelIdRequestDto })
+  @ApiBody({ type: FindFeedbacksByChannelIdRequestDto, required: false })
   @ApiOkResponse({ type: FindFeedbacksByChannelIdResponseDto })
   @Post('feedbacks/search')
   async findByChannelId(
@@ -260,6 +262,41 @@ export class FeedbackController {
   ) {
     return FindFeedbacksByChannelIdResponseDto.transform(
       await this.feedbackService.findByChannelId({ ...body, channelId }),
+    );
+  }
+
+  @ApiOperation({
+    summary: 'Get Feedbacks by Channel',
+    description: `Searches for feedback entries by channel ID with keyword.`,
+  })
+  @ApiParam({
+    name: 'projectId',
+    type: Number,
+    description: 'Project id',
+    example: 1,
+  })
+  @ApiParam({
+    name: 'channelId',
+    type: Number,
+    description: 'Channel id',
+    example: 1,
+  })
+  @ApiOkResponse({ type: FindFeedbacksByChannelIdResponseDto })
+  @Get('feedbacks')
+  async getByChannelId(
+    @Param('channelId', ParseIntPipe) channelId: number,
+    @Query() body: GetFeedbacksByChannelIdRequestDto,
+  ) {
+    return FindFeedbacksByChannelIdResponseDto.transform(
+      await this.feedbackService.findByChannelId({
+        page: body.page,
+        limit: body.limit,
+        query: {
+          searchText: body.searchText,
+          issueName: body.issueName,
+        },
+        channelId,
+      }),
     );
   }
 

--- a/apps/api/src/domains/api/v2/feedback.controller.ts
+++ b/apps/api/src/domains/api/v2/feedback.controller.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  Body,
+  Controller,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBody,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { ApiKeyAuthGuard } from '@/domains/admin/auth/guards';
+import { FindFeedbacksByChannelIdRequestDtoV2 } from '@/domains/admin/feedback/dtos/requests/find-feedbacks-by-channel-id-request-v2.dto';
+import { FindFeedbacksByChannelIdResponseDto } from '../../admin/feedback/dtos/responses';
+import { FeedbackService } from '../../admin/feedback/feedback.service';
+
+@ApiTags('feedbacks-v2')
+@Controller('/v2/projects/:projectId/channels/:channelId')
+@ApiSecurity('apiKey')
+@UseGuards(ApiKeyAuthGuard)
+export class FeedbackV2Controller {
+  constructor(private readonly feedbackService: FeedbackService) {}
+  @ApiOperation({
+    summary: 'Search Feedbacks by Channel (V2)',
+    description: `Searches for feedback entries by channel ID with various filters.`,
+  })
+  @ApiParam({
+    name: 'projectId',
+    type: Number,
+    description: 'Project id',
+    example: 1,
+  })
+  @ApiParam({
+    name: 'channelId',
+    type: Number,
+    description: 'Channel id',
+    example: 1,
+  })
+  @ApiBody({ type: FindFeedbacksByChannelIdRequestDtoV2, required: false })
+  @ApiOkResponse({ type: FindFeedbacksByChannelIdResponseDto })
+  @Post('feedbacks/search')
+  async findByChannelId(
+    @Param('channelId', ParseIntPipe) channelId: number,
+    @Body() body: FindFeedbacksByChannelIdRequestDtoV2,
+  ) {
+    return FindFeedbacksByChannelIdResponseDto.transform(
+      await this.feedbackService.findByChannelIdV2({ ...body, channelId }),
+    );
+  }
+}


### PR DESCRIPTION
- Added `search v2` API which provides enhanced query options.
- Added `GET` method endpoints. 
  - `Get Feedbacks by Channel`: searches related feedbacks in specific field using `fieldKey` and `searchText` keyword.
  - `Get Feedbacks by Issue`: searches related feedbacks using `issueName`.
  - Above two APIs are sharing same endpoint.
- Added `Get Fields` API endpoint.
- Additionally support number, select, multiselect format fields in search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a GET endpoint to retrieve feedback by channel ID using query parameters for pagination and filtering.
  - Added support for filtering feedback by issue name in addition to existing filters.
  - Added a new versioned API endpoint (`/v2/projects/:projectId/channels/:channelId/feedbacks/search`) for advanced feedback search.
  - Added a GET endpoint to retrieve active fields for a channel within a project.

- **Enhancements**
  - Expanded search functionality to support additional field types including number, select, multiSelect, and date.
  - Improved search query construction for more consistent and comprehensive multi-field filtering.

- **Documentation**
  - Enhanced API documentation with detailed descriptions for request parameters and filtering options.
  - Clarified Swagger API documentation for both existing and new endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->