### PR TITLE
feat: implement search max days

### DIFF
--- a/apps/api/integration-test/test-specs/feedback.integration-spec.ts
+++ b/apps/api/integration-test/test-specs/feedback.integration-spec.ts
@@ -385,7 +385,7 @@ describe('FeedbackController (integration)', () => {
           {
             key: 'createdAt',
             value: {
-              gte: DateTime.fromJSDate(new Date(0)).toFormat('yyyy-MM-dd'),
+              gte: DateTime.now().minus({ years: 1 }).toFormat('yyyy-MM-dd'),
               lt: DateTime.now().toFormat('yyyy-MM-dd'),
             },
             condition: QueryV2ConditionsEnum.BETWEEN,

--- a/apps/api/src/configs/modules/typeorm-config/migrations/1746153314386-add-search-max-days-on-channel.ts
+++ b/apps/api/src/configs/modules/typeorm-config/migrations/1746153314386-add-search-max-days-on-channel.ts
@@ -13,20 +13,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { Expose } from 'class-transformer';
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-import type { ImageConfigDto } from './image-config.dto';
+export class AddSearchMaxDaysOnChannel1746153314386
+  implements MigrationInterface
+{
+  name = 'AddSearchMaxDaysOnChannel1746153314386';
 
-export class UpdateChannelDto {
-  @Expose()
-  name: string;
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`channels\` ADD \`search_max_days\` int NOT NULL DEFAULT '365'`,
+    );
+  }
 
-  @Expose()
-  description: string | null;
-
-  @Expose()
-  imageConfig: ImageConfigDto | null;
-
-  @Expose()
-  searchMaxDays: number;
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`channels\` DROP COLUMN \`search_max_days\``,
+    );
+  }
 }

--- a/apps/api/src/domains/admin/channel/channel/channel.controller.spec.ts
+++ b/apps/api/src/domains/admin/channel/channel/channel.controller.spec.ts
@@ -54,6 +54,7 @@ describe('ChannelController', () => {
       const dto = new CreateChannelRequestDto();
       dto.name = faker.string.sample();
       dto.description = faker.string.sample();
+      dto.searchMaxDays = faker.number.int();
       dto.fields = [];
 
       await channelController.create(projectId, dto);

--- a/apps/api/src/domains/admin/channel/channel/channel.entity.ts
+++ b/apps/api/src/domains/admin/channel/channel/channel.entity.ts
@@ -53,6 +53,9 @@ export class ChannelEntity extends CommonEntity {
   @Column({ type: 'json', nullable: true })
   imageConfig: ImageConfig | null;
 
+  @Column('int', { default: 365 })
+  searchMaxDays: number;
+
   @ManyToOne(() => ProjectEntity, (project) => project.channels, {
     onDelete: 'CASCADE',
   })
@@ -87,6 +90,7 @@ export class ChannelEntity extends CommonEntity {
     description: string | null,
     projectId: number,
     imageConfig: ImageConfig | null,
+    searchMaxDays: number,
   ) {
     const channel = new ChannelEntity();
     channel.name = name;
@@ -98,6 +102,7 @@ export class ChannelEntity extends CommonEntity {
     }
     channel.project = new ProjectEntity();
     channel.project.id = projectId;
+    channel.searchMaxDays = searchMaxDays;
 
     return channel;
   }

--- a/apps/api/src/domains/admin/channel/channel/channel.mysql.service.ts
+++ b/apps/api/src/domains/admin/channel/channel/channel.mysql.service.ts
@@ -96,7 +96,7 @@ export class ChannelMySQLService {
 
   @Transactional()
   async update(channelId: number, dto: UpdateChannelDto) {
-    const { name, description, imageConfig } = dto;
+    const { name, description, imageConfig, searchMaxDays } = dto;
     const channel = await this.findById({ channelId });
 
     if (
@@ -115,6 +115,7 @@ export class ChannelMySQLService {
     channel.name = name;
     channel.description = description;
     channel.imageConfig = imageConfig;
+    channel.searchMaxDays = searchMaxDays;
     return await this.repository.save(channel);
   }
 

--- a/apps/api/src/domains/admin/channel/channel/channel.service.spec.ts
+++ b/apps/api/src/domains/admin/channel/channel/channel.service.spec.ts
@@ -54,6 +54,7 @@ describe('ChannelService', () => {
       dto.name = channelFixture.name;
       dto.description = channelFixture.description;
       dto.projectId = channelFixture.project.id;
+      dto.searchMaxDays = channelFixture.searchMaxDays;
       dto.fields = Array.from({ length: fieldCount }).map(createFieldDto);
       jest.spyOn(channelRepo, 'findOneBy').mockResolvedValue(null);
       jest
@@ -70,6 +71,7 @@ describe('ChannelService', () => {
       dto.name = faker.string.sample();
       dto.description = faker.string.sample();
       dto.projectId = faker.number.int();
+      dto.searchMaxDays = faker.number.int();
       dto.fields = Array.from({ length: fieldCount }).map(createFieldDto);
 
       await expect(channelService.create(dto)).rejects.toThrow(
@@ -103,6 +105,7 @@ describe('ChannelService', () => {
       const dto = new UpdateChannelDto();
       dto.name = faker.string.sample();
       dto.description = faker.string.sample();
+      dto.searchMaxDays = faker.number.int();
       jest.spyOn(channelRepo, 'findOne').mockResolvedValueOnce(channelFixture);
       jest.spyOn(channelRepo, 'findOne').mockResolvedValueOnce(null);
 
@@ -116,6 +119,7 @@ describe('ChannelService', () => {
       const dto = new UpdateChannelDto();
       dto.name = channelFixture.name;
       dto.description = faker.string.sample();
+      dto.searchMaxDays = faker.number.int();
 
       await expect(channelService.updateInfo(channelId, dto)).rejects.toThrow(
         ChannelInvalidNameException,

--- a/apps/api/src/domains/admin/channel/channel/dtos/create-channel.dto.ts
+++ b/apps/api/src/domains/admin/channel/channel/dtos/create-channel.dto.ts
@@ -33,6 +33,9 @@ export class CreateChannelDto {
   imageConfig: ImageConfigDto | null;
 
   @Expose()
+  searchMaxDays: number;
+
+  @Expose()
   @Type(() => CreateFieldDto)
   fields: CreateFieldDto[];
 
@@ -48,6 +51,7 @@ export class CreateChannelDto {
       params.description,
       params.projectId,
       params.imageConfig,
+      params.searchMaxDays,
     );
   }
 }

--- a/apps/api/src/domains/admin/channel/channel/dtos/requests/create-channel-request.dto.ts
+++ b/apps/api/src/domains/admin/channel/channel/dtos/requests/create-channel-request.dto.ts
@@ -111,6 +111,10 @@ export class CreateChannelRequestDto {
   @IsObject()
   imageConfig: ImageConfigRequestDto | null;
 
+  @ApiProperty()
+  @IsNumber()
+  searchMaxDays: number;
+
   @ApiProperty({ type: [CreateChannelRequestFieldDto] })
   @Type(() => CreateChannelRequestFieldDto)
   @ValidateNested({ each: true })

--- a/apps/api/src/domains/admin/channel/channel/dtos/requests/update-channel-request.dto.ts
+++ b/apps/api/src/domains/admin/channel/channel/dtos/requests/update-channel-request.dto.ts
@@ -15,6 +15,7 @@
  */
 import { ApiProperty } from '@nestjs/swagger';
 import {
+  IsNumber,
   IsObject,
   IsOptional,
   IsString,
@@ -43,4 +44,8 @@ export class UpdateChannelRequestDto {
   @IsNullable()
   @IsObject()
   imageConfig: ImageConfigRequestDto | null;
+
+  @ApiProperty()
+  @IsNumber()
+  searchMaxDays: number;
 }

--- a/apps/api/src/domains/admin/channel/channel/dtos/responses/find-channel-by-id-response.dto.ts
+++ b/apps/api/src/domains/admin/channel/channel/dtos/responses/find-channel-by-id-response.dto.ts
@@ -38,6 +38,10 @@ export class FindChannelByIdResponseDto {
 
   @Expose()
   @ApiProperty()
+  searchMaxDays: number;
+
+  @Expose()
+  @ApiProperty()
   createdAt: Date;
 
   @Expose()

--- a/apps/api/src/domains/admin/feedback/feedback.service.ts
+++ b/apps/api/src/domains/admin/feedback/feedback.service.ts
@@ -624,11 +624,16 @@ export class FeedbackService {
     }
     dto.fields = fields;
 
-    const searchMaxDays = (
+    let searchMaxDays = (
       await this.channelService.findById({
         channelId: dto.channelId,
       })
     ).searchMaxDays;
+
+    if (dto.query?.searchMaxDays) {
+      searchMaxDays = dto.query.searchMaxDays as number;
+      delete dto.query.searchMaxDays;
+    }
 
     this.validateQuery(dto.query ?? {}, fields, searchMaxDays);
 

--- a/apps/api/src/domains/admin/tenant/tenant.service.ts
+++ b/apps/api/src/domains/admin/tenant/tenant.service.ts
@@ -128,6 +128,7 @@ export class TenantService {
       const feedbacks = await this.feedbackService.findByChannelId({
         channelId: id,
         query: {
+          searchMaxDays: -1,
           createdAt: {
             gte: DateTime.fromJSDate(new Date(0)).toFormat('yyyy-MM-dd'),
             lt: DateTime.now()

--- a/apps/api/src/test-utils/fixtures.ts
+++ b/apps/api/src/test-utils/fixtures.ts
@@ -300,6 +300,7 @@ export const channelFixture = {
   name: faker.string.sample(),
   description: faker.lorem.lines(2),
   imageConfig: null,
+  searchMaxDays: faker.number.int({ min: 1, max: 365 }),
   createdAt: faker.date.past(),
   updatedAt: faker.date.past(),
   project: projectFixture,

--- a/apps/api/src/test-utils/util-functions.ts
+++ b/apps/api/src/test-utils/util-functions.ts
@@ -113,7 +113,7 @@ export const createChannel = async (
     projectId: project.id,
     name: faker.string.alphanumeric(20),
     description: faker.lorem.lines(1),
-    searchMaxDays: faker.number.int({ min: 1, max: 90 }),
+    searchMaxDays: 1000,
     fields: Array.from({
       length: faker.number.int({ min: 1, max: 10 }),
     }).map(() =>

--- a/apps/api/src/test-utils/util-functions.ts
+++ b/apps/api/src/test-utils/util-functions.ts
@@ -113,6 +113,7 @@ export const createChannel = async (
     projectId: project.id,
     name: faker.string.alphanumeric(20),
     description: faker.lorem.lines(1),
+    searchMaxDays: faker.number.int({ min: 1, max: 90 }),
     fields: Array.from({
       length: faker.number.int({ min: 1, max: 10 }),
     }).map(() =>

--- a/apps/api/src/utils/date-utils.ts
+++ b/apps/api/src/utils/date-utils.ts
@@ -13,20 +13,17 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { Expose } from 'class-transformer';
+export default function calculateDaysBetweenDates(
+  date1: string,
+  date2: string,
+): number {
+  const startDate = new Date(date1);
+  const endDate = new Date(date2);
 
-import type { ImageConfigDto } from './image-config.dto';
+  const differenceInMilliseconds = endDate.getTime() - startDate.getTime();
 
-export class UpdateChannelDto {
-  @Expose()
-  name: string;
+  const millisecondsPerDay = 24 * 60 * 60 * 1000;
+  const differenceInDays = differenceInMilliseconds / millisecondsPerDay;
 
-  @Expose()
-  description: string | null;
-
-  @Expose()
-  imageConfig: ImageConfigDto | null;
-
-  @Expose()
-  searchMaxDays: number;
+  return Math.abs(differenceInDays) + 1;
 }

--- a/apps/api/test/feedback/channel.e2e-spec.ts
+++ b/apps/api/test/feedback/channel.e2e-spec.ts
@@ -236,6 +236,7 @@ describe('AppController (e2e)', () => {
       name: faker.string.sample(),
       description: faker.string.sample(),
       fields: Array.from({ length: fieldCount }).map((_) => createFieldDto({})),
+      searchMaxDays: faker.number.int({ min: 1, max: 30 }),
       imageConfig: null,
     });
 

--- a/apps/api/test/feedback/feedback.e2e-spec.ts
+++ b/apps/api/test/feedback/feedback.e2e-spec.ts
@@ -97,6 +97,7 @@ describe('AppController (e2e)', () => {
       fields: Array.from({
         length: faker.number.int({ min: 1, max: 10 }),
       }).map(createFieldDto),
+      searchMaxDays: faker.number.int({ min: 1, max: 30 }),
       imageConfig: null,
     });
 


### PR DESCRIPTION
- Implemented `search max days` which limits the maximum duration for search queries.
  - User can set this value in the admin page.
  - Search queries will be validated based on this value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable "searchMaxDays" setting to channels, allowing control over the maximum date range for feedback searches.
  - "searchMaxDays" is now included in channel creation, update, and retrieval APIs, and is documented and validated accordingly.

- **Improvements**
  - Feedback search endpoints now enforce the "searchMaxDays" limit, restricting queries to the allowed date range per channel.

- **Bug Fixes**
  - Adjusted feedback deletion logic to use a dynamic date range, improving accuracy when removing old feedback.

- **Tests**
  - Updated tests and fixtures to support the new "searchMaxDays" property for channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->