### PR TITLE
change column name to feedback_search_max_days

### DIFF
--- a/apps/api/src/configs/modules/typeorm-config/migrations/1746153314386-add-search-max-days-on-channel.ts
+++ b/apps/api/src/configs/modules/typeorm-config/migrations/1746153314386-add-search-max-days-on-channel.ts
@@ -22,13 +22,13 @@ export class AddSearchMaxDaysOnChannel1746153314386
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE \`channels\` ADD \`search_max_days\` int NOT NULL DEFAULT '365'`,
+      `ALTER TABLE \`channels\` ADD \`feedback_search_max_days\` int NOT NULL DEFAULT '365'`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE \`channels\` DROP COLUMN \`search_max_days\``,
+      `ALTER TABLE \`channels\` DROP COLUMN \`feedback_search_max_days\``,
     );
   }
 }

--- a/apps/api/src/domains/admin/channel/channel/channel.controller.spec.ts
+++ b/apps/api/src/domains/admin/channel/channel/channel.controller.spec.ts
@@ -54,7 +54,7 @@ describe('ChannelController', () => {
       const dto = new CreateChannelRequestDto();
       dto.name = faker.string.sample();
       dto.description = faker.string.sample();
-      dto.searchMaxDays = faker.number.int();
+      dto.feedbackSearchMaxDays = faker.number.int();
       dto.fields = [];
 
       await channelController.create(projectId, dto);

--- a/apps/api/src/domains/admin/channel/channel/channel.entity.ts
+++ b/apps/api/src/domains/admin/channel/channel/channel.entity.ts
@@ -54,7 +54,7 @@ export class ChannelEntity extends CommonEntity {
   imageConfig: ImageConfig | null;
 
   @Column('int', { default: 365 })
-  searchMaxDays: number;
+  feedbackSearchMaxDays: number;
 
   @ManyToOne(() => ProjectEntity, (project) => project.channels, {
     onDelete: 'CASCADE',
@@ -90,7 +90,7 @@ export class ChannelEntity extends CommonEntity {
     description: string | null,
     projectId: number,
     imageConfig: ImageConfig | null,
-    searchMaxDays: number,
+    feedbackSearchMaxDays: number,
   ) {
     const channel = new ChannelEntity();
     channel.name = name;
@@ -102,7 +102,7 @@ export class ChannelEntity extends CommonEntity {
     }
     channel.project = new ProjectEntity();
     channel.project.id = projectId;
-    channel.searchMaxDays = searchMaxDays;
+    channel.feedbackSearchMaxDays = feedbackSearchMaxDays;
 
     return channel;
   }

--- a/apps/api/src/domains/admin/channel/channel/channel.mysql.service.ts
+++ b/apps/api/src/domains/admin/channel/channel/channel.mysql.service.ts
@@ -96,7 +96,7 @@ export class ChannelMySQLService {
 
   @Transactional()
   async update(channelId: number, dto: UpdateChannelDto) {
-    const { name, description, imageConfig, searchMaxDays } = dto;
+    const { name, description, imageConfig, feedbackSearchMaxDays } = dto;
     const channel = await this.findById({ channelId });
 
     if (
@@ -115,7 +115,7 @@ export class ChannelMySQLService {
     channel.name = name;
     channel.description = description;
     channel.imageConfig = imageConfig;
-    channel.searchMaxDays = searchMaxDays;
+    channel.feedbackSearchMaxDays = feedbackSearchMaxDays;
     return await this.repository.save(channel);
   }
 

--- a/apps/api/src/domains/admin/channel/channel/channel.service.spec.ts
+++ b/apps/api/src/domains/admin/channel/channel/channel.service.spec.ts
@@ -54,7 +54,7 @@ describe('ChannelService', () => {
       dto.name = channelFixture.name;
       dto.description = channelFixture.description;
       dto.projectId = channelFixture.project.id;
-      dto.searchMaxDays = channelFixture.searchMaxDays;
+      dto.feedbackSearchMaxDays = channelFixture.feedbackSearchMaxDays;
       dto.fields = Array.from({ length: fieldCount }).map(createFieldDto);
       jest.spyOn(channelRepo, 'findOneBy').mockResolvedValue(null);
       jest
@@ -71,7 +71,7 @@ describe('ChannelService', () => {
       dto.name = faker.string.sample();
       dto.description = faker.string.sample();
       dto.projectId = faker.number.int();
-      dto.searchMaxDays = faker.number.int();
+      dto.feedbackSearchMaxDays = faker.number.int();
       dto.fields = Array.from({ length: fieldCount }).map(createFieldDto);
 
       await expect(channelService.create(dto)).rejects.toThrow(
@@ -105,7 +105,7 @@ describe('ChannelService', () => {
       const dto = new UpdateChannelDto();
       dto.name = faker.string.sample();
       dto.description = faker.string.sample();
-      dto.searchMaxDays = faker.number.int();
+      dto.feedbackSearchMaxDays = faker.number.int();
       jest.spyOn(channelRepo, 'findOne').mockResolvedValueOnce(channelFixture);
       jest.spyOn(channelRepo, 'findOne').mockResolvedValueOnce(null);
 
@@ -119,7 +119,7 @@ describe('ChannelService', () => {
       const dto = new UpdateChannelDto();
       dto.name = channelFixture.name;
       dto.description = faker.string.sample();
-      dto.searchMaxDays = faker.number.int();
+      dto.feedbackSearchMaxDays = faker.number.int();
 
       await expect(channelService.updateInfo(channelId, dto)).rejects.toThrow(
         ChannelInvalidNameException,

--- a/apps/api/src/domains/admin/channel/channel/dtos/create-channel.dto.ts
+++ b/apps/api/src/domains/admin/channel/channel/dtos/create-channel.dto.ts
@@ -33,7 +33,7 @@ export class CreateChannelDto {
   imageConfig: ImageConfigDto | null;
 
   @Expose()
-  searchMaxDays: number;
+  feedbackSearchMaxDays: number;
 
   @Expose()
   @Type(() => CreateFieldDto)
@@ -51,7 +51,7 @@ export class CreateChannelDto {
       params.description,
       params.projectId,
       params.imageConfig,
-      params.searchMaxDays,
+      params.feedbackSearchMaxDays,
     );
   }
 }

--- a/apps/api/src/domains/admin/channel/channel/dtos/requests/create-channel-request.dto.ts
+++ b/apps/api/src/domains/admin/channel/channel/dtos/requests/create-channel-request.dto.ts
@@ -113,7 +113,7 @@ export class CreateChannelRequestDto {
 
   @ApiProperty()
   @IsNumber()
-  searchMaxDays: number;
+  feedbackSearchMaxDays: number;
 
   @ApiProperty({ type: [CreateChannelRequestFieldDto] })
   @Type(() => CreateChannelRequestFieldDto)

--- a/apps/api/src/domains/admin/channel/channel/dtos/requests/update-channel-request.dto.ts
+++ b/apps/api/src/domains/admin/channel/channel/dtos/requests/update-channel-request.dto.ts
@@ -47,5 +47,5 @@ export class UpdateChannelRequestDto {
 
   @ApiProperty()
   @IsNumber()
-  searchMaxDays: number;
+  feedbackSearchMaxDays: number;
 }

--- a/apps/api/src/domains/admin/channel/channel/dtos/responses/find-channel-by-id-response.dto.ts
+++ b/apps/api/src/domains/admin/channel/channel/dtos/responses/find-channel-by-id-response.dto.ts
@@ -38,7 +38,7 @@ export class FindChannelByIdResponseDto {
 
   @Expose()
   @ApiProperty()
-  searchMaxDays: number;
+  feedbackSearchMaxDays: number;
 
   @Expose()
   @ApiProperty()

--- a/apps/api/src/domains/admin/channel/channel/dtos/update-channel.dto.ts
+++ b/apps/api/src/domains/admin/channel/channel/dtos/update-channel.dto.ts
@@ -28,5 +28,5 @@ export class UpdateChannelDto {
   imageConfig: ImageConfigDto | null;
 
   @Expose()
-  searchMaxDays: number;
+  feedbackSearchMaxDays: number;
 }

--- a/apps/api/src/domains/admin/feedback/feedback.service.ts
+++ b/apps/api/src/domains/admin/feedback/feedback.service.ts
@@ -96,7 +96,7 @@ export class FeedbackService {
   private validateQuery(
     query: FindFeedbacksByChannelIdDto['query'],
     fields: FieldEntity[],
-    searchMaxDays: number,
+    feedbackSearchMaxDays: number,
   ) {
     const fieldsByKey = fields.reduce(
       (fields: Record<string, FieldEntity>, field) => {
@@ -149,14 +149,14 @@ export class FeedbackService {
             throw new BadRequestException(`${fieldKey} must be DateTimeRange`);
 
           if (
-            searchMaxDays >= 0 &&
+            feedbackSearchMaxDays >= 0 &&
             calculateDaysBetweenDates(
               (query[fieldKey] as TimeRange).gte,
               (query[fieldKey] as TimeRange).lt,
-            ) > searchMaxDays
+            ) > feedbackSearchMaxDays
           ) {
             throw new BadRequestException(
-              `${fieldKey} must be less than ${searchMaxDays} days`,
+              `${fieldKey} must be less than ${feedbackSearchMaxDays} days`,
             );
           }
           break;
@@ -191,7 +191,7 @@ export class FeedbackService {
   private validateQueryV2(
     queries: FindFeedbacksByChannelIdDtoV2['queries'],
     fields: FieldEntity[],
-    searchMaxDays: number,
+    feedbackSearchMaxDays: number,
   ) {
     const fieldsByKey = fields.reduce(
       (fields: Record<string, FieldEntity>, field) => {
@@ -235,14 +235,14 @@ export class FeedbackService {
             throw new BadRequestException(`${fieldKey} must be DateTimeRange`);
 
           if (
-            searchMaxDays >= 0 &&
+            feedbackSearchMaxDays >= 0 &&
             calculateDaysBetweenDates(
               (fieldValue as TimeRange).gte,
               (fieldValue as TimeRange).lt,
-            ) > searchMaxDays
+            ) > feedbackSearchMaxDays
           ) {
             throw new BadRequestException(
-              `${fieldKey} must be less than ${searchMaxDays} days`,
+              `${fieldKey} must be less than ${feedbackSearchMaxDays} days`,
             );
           }
           break;
@@ -654,18 +654,18 @@ export class FeedbackService {
     delete dto.query?.issueName;
     if (!dto.query?.searchText) delete dto.query?.searchText;
 
-    let searchMaxDays = (
+    let feedbackSearchMaxDays = (
       await this.channelService.findById({
         channelId: dto.channelId,
       })
-    ).searchMaxDays;
+    ).feedbackSearchMaxDays;
 
-    if (dto.query?.searchMaxDays) {
-      searchMaxDays = dto.query.searchMaxDays as number;
-      delete dto.query.searchMaxDays;
+    if (dto.query?.feedbackSearchMaxDays) {
+      feedbackSearchMaxDays = dto.query.feedbackSearchMaxDays as number;
+      delete dto.query.feedbackSearchMaxDays;
     }
 
-    this.validateQuery(dto.query ?? {}, fields, searchMaxDays);
+    this.validateQuery(dto.query ?? {}, fields, feedbackSearchMaxDays);
 
     const feedbacksByPagination =
       this.configService.get('opensearch.use') ?
@@ -696,14 +696,14 @@ export class FeedbackService {
     }
     dto.fields = fields;
 
-    const searchMaxDays = (
+    const feedbackSearchMaxDays = (
       await this.channelService.findById({
         channelId: dto.channelId,
       })
-    ).searchMaxDays;
+    ).feedbackSearchMaxDays;
 
-    this.validateQueryV2(dto.queries, fields, searchMaxDays);
-    this.validateQueryV2(dto.defaultQueries, fields, searchMaxDays);
+    this.validateQueryV2(dto.queries, fields, feedbackSearchMaxDays);
+    this.validateQueryV2(dto.defaultQueries, fields, feedbackSearchMaxDays);
 
     const feedbacksByPagination =
       this.configService.get('opensearch.use') ?
@@ -871,14 +871,14 @@ export class FeedbackService {
       }
     }
 
-    const searchMaxDays = (
+    const feedbackSearchMaxDays = (
       await this.channelService.findById({
         channelId: dto.channelId,
       })
-    ).searchMaxDays;
+    ).feedbackSearchMaxDays;
 
-    this.validateQueryV2(dto.queries, fields, searchMaxDays);
-    this.validateQueryV2(dto.defaultQueries, fields, searchMaxDays);
+    this.validateQueryV2(dto.queries, fields, feedbackSearchMaxDays);
+    this.validateQueryV2(dto.defaultQueries, fields, feedbackSearchMaxDays);
 
     const fieldsByKey: Record<string, FieldEntity> = fields.reduce(
       (prev: Record<string, FieldEntity>, field) => {

--- a/apps/api/src/domains/admin/tenant/tenant.service.ts
+++ b/apps/api/src/domains/admin/tenant/tenant.service.ts
@@ -128,7 +128,7 @@ export class TenantService {
       const feedbacks = await this.feedbackService.findByChannelId({
         channelId: id,
         query: {
-          searchMaxDays: -1,
+          feedbackSearchMaxDays: -1,
           createdAt: {
             gte: DateTime.fromJSDate(new Date(0)).toFormat('yyyy-MM-dd'),
             lt: DateTime.now()

--- a/apps/api/src/test-utils/fixtures.ts
+++ b/apps/api/src/test-utils/fixtures.ts
@@ -300,7 +300,7 @@ export const channelFixture = {
   name: faker.string.sample(),
   description: faker.lorem.lines(2),
   imageConfig: null,
-  searchMaxDays: faker.number.int({ min: 1, max: 365 }),
+  feedbackSearchMaxDays: faker.number.int({ min: 1, max: 365 }),
   createdAt: faker.date.past(),
   updatedAt: faker.date.past(),
   project: projectFixture,

--- a/apps/api/src/test-utils/util-functions.ts
+++ b/apps/api/src/test-utils/util-functions.ts
@@ -113,7 +113,7 @@ export const createChannel = async (
     projectId: project.id,
     name: faker.string.alphanumeric(20),
     description: faker.lorem.lines(1),
-    searchMaxDays: 1000,
+    feedbackSearchMaxDays: 1000,
     fields: Array.from({
       length: faker.number.int({ min: 1, max: 10 }),
     }).map(() =>

--- a/apps/api/test/feedback/channel.e2e-spec.ts
+++ b/apps/api/test/feedback/channel.e2e-spec.ts
@@ -236,7 +236,7 @@ describe('AppController (e2e)', () => {
       name: faker.string.sample(),
       description: faker.string.sample(),
       fields: Array.from({ length: fieldCount }).map((_) => createFieldDto({})),
-      searchMaxDays: faker.number.int({ min: 1, max: 30 }),
+      feedbackSearchMaxDays: faker.number.int({ min: 1, max: 30 }),
       imageConfig: null,
     });
 

--- a/apps/api/test/feedback/feedback.e2e-spec.ts
+++ b/apps/api/test/feedback/feedback.e2e-spec.ts
@@ -97,7 +97,7 @@ describe('AppController (e2e)', () => {
       fields: Array.from({
         length: faker.number.int({ min: 1, max: 10 }),
       }).map(createFieldDto),
-      searchMaxDays: faker.number.int({ min: 1, max: 30 }),
+      feedbackSearchMaxDays: faker.number.int({ min: 1, max: 30 }),
       imageConfig: null,
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the property and related references from `searchMaxDays` to `feedbackSearchMaxDays` across all channel-related APIs, DTOs, entities, and services for improved consistency.
- **Tests**
  - Updated all affected test cases and fixtures to use the new property name `feedbackSearchMaxDays` instead of `searchMaxDays`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->