### PR TITLE
fix: fix filter bug in mysql

### DIFF
--- a/apps/api/src/domains/admin/feedback/feedback.mysql.service.ts
+++ b/apps/api/src/domains/admin/feedback/feedback.mysql.service.ts
@@ -370,21 +370,27 @@ export class FeedbackMySQLService {
                   SELECT feedbacks_id
                   FROM feedbacks_issues_issues
                   GROUP BY feedbacks_id
-                  HAVING COUNT(DISTINCT issues_id) = :arrayLength
-                  AND COUNT(DISTINCT CASE WHEN issues_id IN (:...issueIds) THEN issues_id END) = :arrayLength
+                  HAVING COUNT(DISTINCT issues_id) = :arrayLength${paramName}
+                  AND COUNT(DISTINCT CASE WHEN issues_id IN (:...issueIds${paramName}) THEN issues_id END) = :arrayLength${paramName}
                 )`,
-                { arrayLength: issueIds.length, issueIds },
+                {
+                  [`arrayLength${paramName}`]: issueIds.length,
+                  [`issueIds${paramName}`]: issueIds,
+                },
               );
             } else if (condition === QueryV2ConditionsEnum.CONTAINS) {
               qb[method](
                 `feedbacks.id IN (
                   SELECT feedbacks_id
                   FROM feedbacks_issues_issues
-                  WHERE issues_id IN (:...issueIds)
+                  WHERE issues_id IN (:...issueIds${paramName})
                   GROUP BY feedbacks_id
-                  HAVING COUNT(DISTINCT issues_id) = :arrayLength
+                  HAVING COUNT(DISTINCT issues_id) = :arrayLength${paramName}
                 )`,
-                { arrayLength: issueIds.length, issueIds },
+                {
+                  [`arrayLength${paramName}`]: issueIds.length,
+                  [`issueIds${paramName}`]: issueIds,
+                },
               );
             }
           } else if (fieldKey === 'updatedAt') {
@@ -415,7 +421,7 @@ export class FeedbackMySQLService {
 
               if (condition === QueryV2ConditionsEnum.IS) {
                 qb[method](
-                  `JSON_LENGTH(JSON_EXTRACT(feedbacks.data, '$."${fieldKey}"')) = :arrayLength AND JSON_CONTAINS(
+                  `JSON_LENGTH(JSON_EXTRACT(feedbacks.data, '$."${fieldKey}"')) = :arrayLength${paramName} AND JSON_CONTAINS(
                     (SELECT JSON_ARRAYAGG(jt.value) FROM JSON_TABLE(
                       JSON_EXTRACT(feedbacks.data, '$."${fieldKey}"'),
                       '$[*]' COLUMNS(value VARCHAR(255) PATH '$')
@@ -423,12 +429,12 @@ export class FeedbackMySQLService {
                     JSON_ARRAY(${values.map((optionKey) => `'${optionKey}'`).join(', ')}),
                     '$'
                   )`,
-                  { arrayLength: values.length },
+                  { [`arrayLength${paramName}`]: values.length },
                 );
               } else if (condition === QueryV2ConditionsEnum.CONTAINS) {
                 if (values.length > 0) {
                   qb[method](
-                    `JSON_LENGTH(JSON_EXTRACT(feedbacks.data, '$."${fieldKey}"')) >= :arrayLength AND JSON_CONTAINS(
+                    `JSON_LENGTH(JSON_EXTRACT(feedbacks.data, '$."${fieldKey}"')) >= :arrayLength${paramName} AND JSON_CONTAINS(
                       (SELECT JSON_ARRAYAGG(jt.value) FROM JSON_TABLE(
                         JSON_EXTRACT(feedbacks.data, '$."${fieldKey}"'),
                         '$[*]' COLUMNS(value VARCHAR(255) PATH '$')
@@ -436,7 +442,7 @@ export class FeedbackMySQLService {
                       JSON_ARRAY(${values.map((optionKey) => `'${optionKey}'`).join(', ')}),
                       '$'
                     )`,
-                    { arrayLength: values.length },
+                    { [`arrayLength${paramName}`]: values.length },
                   );
                 } else {
                   qb[method]('1 = 0');


### PR DESCRIPTION
- Fixed filter bug in mysql
  - Multiple parameters in query are not distinguished

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of feedback filtering by preventing parameter conflicts when searching by issue IDs or multi-select fields. Users should experience more accurate and consistent results when applying these filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->