### PR TITLE
feat: change temperature default value

### DIFF
--- a/apps/api/src/configs/modules/typeorm-config/migrations/1754965389371-change-temperature-default-value.ts
+++ b/apps/api/src/configs/modules/typeorm-config/migrations/1754965389371-change-temperature-default-value.ts
@@ -34,11 +34,11 @@ export class ChangeTemperatureDefaultValue1754965389371
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `ALTER TABLE \`ai_field_templates\`
-        MODIFY COLUMN \`temperature\` float NOT NULL DEFAULT 0.5`,
+        MODIFY COLUMN \`temperature\` float NOT NULL DEFAULT 0.7`,
     );
     await queryRunner.query(
       `ALTER TABLE \`ai_issue_templates\`
-        MODIFY COLUMN \`temperature\` float NOT NULL DEFAULT 0.5`,
+        MODIFY COLUMN \`temperature\` float NOT NULL DEFAULT 0.7`,
     );
   }
 }

--- a/apps/api/src/configs/modules/typeorm-config/migrations/1754965389371-change-temperature-default-value.ts
+++ b/apps/api/src/configs/modules/typeorm-config/migrations/1754965389371-change-temperature-default-value.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ChangeTemperatureDefaultValue1754965389371
+  implements MigrationInterface
+{
+  name = 'ChangeTemperatureDefaultValue1754965389371';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`ai_field_templates\`
+        MODIFY COLUMN \`temperature\` float NOT NULL DEFAULT 0.5`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ai_issue_templates\`
+        MODIFY COLUMN \`temperature\` float NOT NULL DEFAULT 0.5`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`ai_field_templates\`
+        MODIFY COLUMN \`temperature\` float NOT NULL DEFAULT 0.5`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`ai_issue_templates\`
+        MODIFY COLUMN \`temperature\` float NOT NULL DEFAULT 0.5`,
+    );
+  }
+}

--- a/apps/api/src/domains/admin/project/ai/ai-field-templates.entity.ts
+++ b/apps/api/src/domains/admin/project/ai/ai-field-templates.entity.ts
@@ -30,7 +30,7 @@ export class AIFieldTemplatesEntity extends CommonEntity {
   @Column('varchar')
   model: string | null;
 
-  @Column('float', { default: 0.7 })
+  @Column('float', { default: 0.5 })
   temperature: number;
 
   @ManyToOne(() => ProjectEntity, (project) => project.aiFieldTemplates, {

--- a/apps/api/src/domains/admin/project/ai/ai-issue-templates.entity.ts
+++ b/apps/api/src/domains/admin/project/ai/ai-issue-templates.entity.ts
@@ -38,7 +38,7 @@ export class AIIssueTemplatesEntity extends CommonEntity {
   @Column('varchar')
   model: string | null;
 
-  @Column('float', { default: 0.7 })
+  @Column('float', { default: 0.5 })
   temperature: number;
 
   @Column('int', { default: 3 })

--- a/apps/api/src/domains/admin/project/ai/ai.service.ts
+++ b/apps/api/src/domains/admin/project/ai/ai.service.ts
@@ -208,27 +208,27 @@ export class AIService {
         title: 'Feedback Summary',
         prompt: 'Summarize the following feedback within a sentences',
         model: model,
-        temperature: 0.7,
+        temperature: 0.5,
       },
       {
         title: 'Feedback Sentiment Analysis',
         prompt:
           'Analyze the sentiment of the following feedback and express it both as a sentiment label (e.g., positive, negative, neutral) and as a number from 0 to 10.',
         model: model,
-        temperature: 0.7,
+        temperature: 0.5,
       },
       {
         title: 'Feedback Translation',
         prompt: 'Translate the following feedback to English',
         model: model,
-        temperature: 0.7,
+        temperature: 0.5,
       },
       {
         title: 'Feedback Keyword Extraction',
         prompt:
           'Extract the 2-3 most important keywords from the following feedback.',
         model: model,
-        temperature: 0.7,
+        temperature: 0.5,
       },
     ];
 


### PR DESCRIPTION
- Change temperature default value from 0.7 to 0.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated default AI temperature from 0.7 to 0.5 across AI templates, yielding slightly more consistent and less variable outputs.
  - Applies to default templates for Feedback Summary, Sentiment Analysis, Translation, and Keyword Extraction.
  - Affects new templates/entries that don’t specify a temperature; existing records remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->