### PR TITLE
feat: add FeedbackImage component and integrate it into ImagePreviewButton and SheetDetailTable

### DIFF
--- a/apps/web/src/shared/ui/feedback-image.tsx
+++ b/apps/web/src/shared/ui/feedback-image.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { useMemo } from 'react';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+
+import { useOAIQuery } from '../lib';
+
+interface Props {
+  url: string;
+}
+
+const FeedbackImage = ({ url }: Props) => {
+  const router = useRouter();
+  const projectId = Number(router.query.projectId);
+  const channelId = Number(router.query.channelId);
+
+  const { data: channelData } = useOAIQuery({
+    path: '/api/admin/projects/{projectId}/channels/{channelId}',
+    variables: { channelId, projectId },
+    queryOptions: {
+      enabled:
+        router.isReady &&
+        Number.isFinite(projectId) &&
+        Number.isFinite(channelId),
+    },
+  });
+
+  const imageKey = useMemo(() => {
+    if (!channelData?.imageConfig?.enablePresignedUrlDownload) return url;
+
+    let parsed: URL | null = null;
+    try {
+      parsed = new URL(
+        url,
+        typeof window !== 'undefined' ?
+          window.location.href
+        : 'http://localhost',
+      );
+    } catch {
+      return url;
+    }
+    if (!/^https?:$/.test(parsed.protocol)) return url;
+
+    const rawPath = parsed.pathname.replace(/^\/+/, '');
+    let key = rawPath;
+    try {
+      key = decodeURIComponent(rawPath);
+    } catch {
+      /* keep raw */
+    }
+
+    const host = parsed.hostname;
+    const parts = key.split('/', 2);
+    if (
+      (host === 's3.amazonaws.com' || host.startsWith('s3.')) &&
+      parts.length >= 2
+    ) {
+      return parts.slice(1).join('/');
+    }
+    return key;
+  }, [channelData, url]);
+
+  const { data: presignedUrl } = useOAIQuery({
+    path: '/api/admin/projects/{projectId}/channels/{channelId}/image-download-url',
+    variables: { channelId, projectId, imageKey },
+    queryOptions: {
+      enabled: Boolean(
+        imageKey && channelData?.imageConfig?.enablePresignedUrlDownload,
+      ),
+    },
+  });
+
+  return (
+    <Image
+      src={presignedUrl ?? url}
+      alt={presignedUrl ?? url}
+      className="cursor-pointer object-cover"
+      fill
+    />
+  );
+};
+
+export default FeedbackImage;

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -51,5 +51,7 @@ export { default as SheetDetailTable } from './sheet-detail-table.ui';
 export * from './table-filter-popover';
 export { default as NoProjectDialogInProjectCreation } from './no-project-dialog-in-project-creation.ui';
 export { default as InfiniteScrollArea } from './infinite-scroll-area.ui';
+export { default as FeedbackImage } from './feedback-image';
+
 export * from './card.ui';
 export * from './slider.ui';

--- a/apps/web/src/shared/ui/sheet-detail-table.ui.tsx
+++ b/apps/web/src/shared/ui/sheet-detail-table.ui.tsx
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import Image from 'next/image';
 import { useRouter } from 'next/router';
 import dayjs from 'dayjs';
 import Linkify from 'linkify-react';
@@ -39,6 +38,7 @@ import type { BadgeColor } from '../constants/color-map';
 import { BADGE_COLOR_MAP } from '../constants/color-map';
 import { useOAIMutation, usePermissions } from '../lib';
 import { cn } from '../utils';
+import FeedbackImage from './feedback-image';
 import ImagePreviewButton from './image-preview-button';
 import {
   DatePicker,
@@ -201,7 +201,7 @@ const SheetDetailTable = (props: Props) => {
               className="bg-neutral-tertiary relative h-16 w-16 overflow-hidden rounded"
               key={index}
             >
-              <Image src={v} alt={v} fill />
+              <FeedbackImage url={v} />
               <div className="absolute inset-1/2 flex h-fit w-fit -translate-x-1/2 -translate-y-1/2 items-center justify-center">
                 <ImagePreviewButton
                   urls={value as string[]}
@@ -363,7 +363,7 @@ const SheetDetailTable = (props: Props) => {
               className="bg-neutral-tertiary relative h-16 w-16 overflow-hidden rounded"
               key={v}
             >
-              <Image src={v} alt={v} fill />
+              <FeedbackImage url={v} />
               <div className="absolute inset-1/2 flex h-fit w-fit -translate-x-1/2 -translate-y-1/2 items-center justify-center gap-1">
                 <ImagePreviewButton
                   urls={value as string[]}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added FeedbackImage for secure, seamless image display using presigned URLs when available.
  - ImagePreviewButton now supports an initialIndex prop to open the gallery at a specific image with synced thumbnails/navigation.
- Refactor
  - Replaced direct image rendering with FeedbackImage in image preview and sheet detail table for consistent behavior.
  - Consolidated image URL handling and removed legacy presigned URL logic from UI components.
- Exports
  - Exposed FeedbackImage via the shared UI index for reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->