### PR TITLE
fix: add minimum release age configuration to .npmrc and renovate.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 node-linker=hoisted
+min-release-age=3d

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 node-linker=hoisted
-min-release-age=3d
+min-release-age=3

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,10 @@
     {
       "matchPackageNames": ["next"],
       "allowedVersions": "<16.0.0"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
     }
   ],
   "updateInternalDeps": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enforce a minimum release age of 3 days for all npm packages, ensuring only stable and well-tested versions are adopted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->